### PR TITLE
add markdownlint and shellcheck wrappers

### DIFF
--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    TOP_DIR="${1:-.}"
+    find "${TOP_DIR}" -type d \( -path ./vendor -o -path ./.github \) -prune -o -name '*.md' -exec mdl --style all --warnings {} \+
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2 \
+        /workdir/hack/markdownlint.sh "$@"
+fi

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+IS_CONTAINER="${IS_CONTAINER:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ "${IS_CONTAINER}" != "false" ]; then
+    TOP_DIR="${1:-.}"
+    find "${TOP_DIR}" -name '*.sh' -exec shellcheck -s bash {} \+
+else
+    "${CONTAINER_RUNTIME}" run --rm \
+        --env IS_CONTAINER=TRUE \
+        --volume "${PWD}:/workdir:ro,z" \
+        --entrypoint sh \
+        --workdir /workdir \
+        docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7 \
+        /workdir/hack/shellcheck.sh "$@"
+fi

--- a/ipxe-builder/Dockerfile
+++ b/ipxe-builder/Dockerfile
@@ -4,4 +4,4 @@ RUN dnf install -y gcc git-core make perl xz-devel python3-setuptools python3-ji
 
 COPY buildipxe embed.ipxe.j2 /bin/
 
-CMD /bin/buildipxe
+CMD /bin/buildipxe.sh

--- a/ipxe-builder/buildipxe.sh
+++ b/ipxe-builder/buildipxe.sh
@@ -89,7 +89,8 @@ fi
 sed -i 's/^\/\/#define[ \t]CONSOLE_SERIAL/#define\tCONSOLE_SERIAL/g' \
     "config/console.h"
 
-/usr/bin/make "bin/undionly.kpxe" "bin-${ARCH}-efi/snponly.efi" ${IPXE_BUILD_OPTIONS[@]}
+# shellcheck disable=SC2086
+/usr/bin/make "bin/undionly.kpxe" "bin-${ARCH}-efi/snponly.efi" ${IPXE_BUILD_OPTIONS}
 
 mkdir -p "${IPXE_CUSTOM_FIRMWARE_DIR}"
 # These files will be copied by the rundnsmasq script to the shared volume.


### PR DESCRIPTION
This commit:
  - Adds markdownlint and shellcheck wrapper scripts to be used locally and in CI for syntax linting.