### PR TITLE
bump markdownlint to 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,9 @@ This repository provides the ability to build an OCI container that:
 - Provides customizable custom IPXE firmware building functionality.
 
 - Ability to either build IPXE firmware from an already existing cash.
-
 - Ability to pull IPXE firmware source code and build the firmware based
   on that.
-
 - Embed custom IPXE script in the firmware.
-
 - Enable IPV6 or TLS 1.3 support for the firmware.
 
 ### External runtime dependencies
@@ -22,10 +19,8 @@ This repository provides the ability to build an OCI container that:
 - In order to build the iPXE firmware with TLS support, the user needs to
   provide relevant certificate and certificate key files e.g. via a mounted
   volume.
-
 - If the ipxe-builder is instructed to build from existing iPXE source code
   cache, then the cahce has to be provided e.g. via a mounted volume.
-
 - In order to get a usable output the user needs to mount a directory
   where the iPXE builder script can put the build outputs.
 

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -14,6 +14,6 @@ else
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/pipelinecomponents/markdownlint:0.12.0@sha256:0b8f9fcf0410257b2f3548f67ffe25934cfc9877a618b9f85afcf345a25804a2 \
+        docker.io/pipelinecomponents/markdownlint:0.13.0@sha256:9c0cdfb64fd3f1d3bdc5181629b39c2e43b6a52fc9fdc146611e1860845bbae0 \
         /workdir/hack/markdownlint.sh "$@"
 fi


### PR DESCRIPTION
Bump markdownlint to 0.13.0.

Also fix the linting issues, so no ignore rules need to be created.

TODO: bump in project-infra after all repos are bumped.