### PR TITLE
Fix the image build for ipxe-builder

### DIFF
--- a/ipxe-builder/Dockerfile
+++ b/ipxe-builder/Dockerfile
@@ -2,6 +2,6 @@ FROM quay.io/centos/centos:stream9
 
 RUN dnf install -y gcc git-core make perl xz-devel python3-setuptools python3-jinja2
 
-COPY buildipxe embed.ipxe.j2 /bin/
+COPY buildipxe.sh embed.ipxe.j2 /bin/
 
 CMD /bin/buildipxe.sh


### PR DESCRIPTION
Correct the file path of buildipxe shell script in the dockerfile, file extension is missing
This will fix the image build workflow and issue #10

While being a "prerequisite" for the followup PR of monitoring the image build workflow #9  