### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - lentzi90
- - Rozzii
+- utility-images-maintainers
 
 reviewers:
- - dtantsur
- - elfosardo
- - kashifest
- - mboukhalfa
- - tuminoid
+- utility-images-maintainers
+- utility-images-reviewers
 
 emeritus_reviewers:
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  utility-images-maintainers:
+  - lentzi90
+  - Rozzii
+
+  utility-images-reviewers:
+  - dtantsur
+  - elfosardo
+  - kashifest
+  - mboukhalfa
+  - tuminoid


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.