### PR TITLE
Uplift fakeIPA python requirements 

### DIFF
--- a/fake-ipa/Dockerfile
+++ b/fake-ipa/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.9-slim
+ARG BASE_IMAGE=python:3.12-slim
 FROM $BASE_IMAGE
 ENV PBR_VERSION=6.0.0
 COPY . /app/

--- a/fake-ipa/requirements.txt
+++ b/fake-ipa/requirements.txt
@@ -1,3 +1,3 @@
-Flask>=1.0.2
-requests>=2.14.2
-tenacity>=6.2.0
+Flask>=3.0.3
+requests>=2.32.3
+tenacity>=9.0.0


### PR DESCRIPTION
Uplift base-image python version to 3.12 and pip requirements :
```
Flask>=3.0.3
requests>=2.32.3
tenacity>=9.0.0
```
