### PR TITLE
🌱 Use https with heartbeating

### DIFF
--- a/fake-ipa/fake_ipa/heartbeater.py
+++ b/fake-ipa/fake_ipa/heartbeater.py
@@ -97,7 +97,7 @@ class Heatbeater:
                 advertise_address=Host(
                     hostname=self._config['FAKE_IPA_ADVERTISE_ADDRESS_IP'],
                     port=self._config['FAKE_IPA_ADVERTISE_ADDRESS_PORT']),
-                advertise_protocol="http",
+                advertise_protocol="https",
                 generated_cert=None,
             )
             self._logger.info('heartbeat successful')


### PR DESCRIPTION
Ironic by default require TLS from agent https://github.com/openstack/ironic/blob/f182c33b4d2c8a15b167896f0565c0c8dd667912/ironic/conf/agent.py#L155

Slack discussion https://kubernetes.slack.com/archives/CHD49TLE7/p1721659136820069