### PR TITLE
:sparkles: move keepalived here from BMO repo

### DIFF
--- a/keepalived/Dockerfile
+++ b/keepalived/Dockerfile
@@ -1,0 +1,16 @@
+# Support FROM override
+ARG BASE_IMAGE=ubuntu:22.04
+
+FROM $BASE_IMAGE
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update && \
+    apt-get -y install keepalived && \
+    apt-get -y clean
+
+COPY sample.keepalived.conf /etc/keepalived/keepalived.conf
+COPY manage-keepalived.sh configure-nonroot.sh /bin/
+
+RUN /bin/configure-nonroot.sh && rm /bin/configure-nonroot.sh
+
+CMD ["/bin/bash", "/bin/manage-keepalived.sh"]

--- a/keepalived/configure-nonroot.sh
+++ b/keepalived/configure-nonroot.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+
+set -eux
+
+# create nonroot image matching the keepalived manifest
+NONROOT_USER="nonroot"
+NONROOT_GROUP="nonroot"
+NONROOT_UID=65532
+NONROOT_GID=65532
+
+# run as non-root, allow editing the keepalived.conf during startup
+groupadd -g "${NONROOT_GID}" "${NONROOT_GROUP}"
+useradd -u "${NONROOT_UID}" -g "${NONROOT_GID}" -m "${NONROOT_USER}"
+
+mkdir -p /run/keepalived
+chown -R root:"${NONROOT_GROUP}" /etc/keepalived /run/keepalived
+chmod 2775 /etc/keepalived /run/keepalived
+chmod 664 /etc/keepalived/keepalived.conf
+
+setcap "cap_net_raw,cap_net_broadcast,cap_net_admin=+eip" /usr/sbin/keepalived

--- a/keepalived/manage-keepalived.sh
+++ b/keepalived/manage-keepalived.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+set -eux
+
+export assignedIP="${PROVISIONING_IP}/32"
+export interface="${PROVISIONING_INTERFACE}"
+
+sed -i "s~INTERFACE~${interface}~g" /etc/keepalived/keepalived.conf
+sed -i "s~CHANGEIP~${assignedIP}~g" /etc/keepalived/keepalived.conf
+
+exec /usr/sbin/keepalived -n -l -p /run/keepalived/keepalived.pid -r /run/keepalived/vrrp.pid

--- a/keepalived/sample.keepalived.conf
+++ b/keepalived/sample.keepalived.conf
@@ -1,0 +1,20 @@
+! Configuration File for keepalived
+global_defs {
+    notification_email {
+    sysadmin@example.com
+    support@example.com
+    }
+    notification_email_from lb@example.com
+    smtp_server localhost
+    smtp_connect_timeout 30
+}
+vrrp_instance VI_1 {
+    state MASTER
+    interface INTERFACE
+    virtual_router_id 1
+    priority 101
+    advert_int 1
+    virtual_ipaddress {
+        CHANGEIP
+    }
+}


### PR DESCRIPTION
This PR:
 - Moves the project used to build the Metal3 keepalived container from
   the BMO repository to this repository

These changes were needed for two related reasons.
 - The community has decided that there is no reason to keep the keepalived
   files in BMO and they much better fit for the utility-images repository.
 
 Related issues:
- https://github.com/metal3-io/baremetal-operator/issues/2085