### PR TITLE
:seedling: group all github action bumps into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     interval: "monthly"
     day: "friday"
   target-branch: main
+  ## group all action bumps into single PR
+  groups:
+    all-github-actions:
+      patterns: ["*"]
   commit-message:
     prefix: ":seedling:"
   labels:


### PR DESCRIPTION
Group all GitHub Action bumps into single bump PR. We cannot really test them anyways, so the review process is more or less eyeballing the release notes and Github provided compatibility numbers.

In addition, having many action bump "pollutes" our release notes with user-irrelevant seedling PRs.