### PR TITLE
:sparkles: add keepalived image build workflow

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -33,3 +33,15 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  build_keepalived:
+    name: Build keepalived container image
+    if: github.repository == 'metal3-io/utility-images'
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main
+    with:
+      image-name: 'keepalived'
+      dockerfile-directory: keepalived
+      pushImage: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
This PR:
 - Adds keepalived container image build workflow

This commit is needed in order to be able to build the newly introduced keepalived container.

This needs to get merged right after https://github.com/metal3-io/utility-images/pull/27 