### PR TITLE
:seedling: add labels to Dockerfiles

### DIFF
--- a/fake-ipa/Dockerfile
+++ b/fake-ipa/Dockerfile
@@ -1,5 +1,16 @@
 ARG BASE_IMAGE=python:3.12-slim
+
 FROM $BASE_IMAGE
+
+# image.version is set during image build by automation
+LABEL org.opencontainers.image.authors="metal3-dev@googlegroups.com"
+LABEL org.opencontainers.image.description="Metal3 Fake IPA container image"
+LABEL org.opencontainers.image.documentation="https://github.com/metal3-io/utility-images"
+LABEL org.opencontainers.image.licenses="Apache License 2.0"
+LABEL org.opencontainers.image.title="Metal3 Fake IPA"
+LABEL org.opencontainers.image.url="https://github.com/metal3-io/utility-images"
+LABEL org.opencontainers.image.vendor="Metal3-io"
+
 ENV PBR_VERSION=6.0.0
 COPY . /app/
 WORKDIR /app/

--- a/ipxe-builder/Dockerfile
+++ b/ipxe-builder/Dockerfile
@@ -1,5 +1,14 @@
 FROM quay.io/centos/centos:stream9
 
+# image.version is set during image build by automation
+LABEL org.opencontainers.image.authors="metal3-dev@googlegroups.com"
+LABEL org.opencontainers.image.description="Metal3 iPXE Builder container image"
+LABEL org.opencontainers.image.documentation="https://github.com/metal3-io/utility-images"
+LABEL org.opencontainers.image.licenses="Apache License 2.0"
+LABEL org.opencontainers.image.title="Metal3 iPXE Builder"
+LABEL org.opencontainers.image.url="https://github.com/metal3-io/utility-images"
+LABEL org.opencontainers.image.vendor="Metal3-io"
+
 RUN dnf install -y gcc git-core make perl xz-devel python3-setuptools python3-jinja2
 
 COPY buildipxe.sh embed.ipxe.j2 /bin/

--- a/keepalived/Dockerfile
+++ b/keepalived/Dockerfile
@@ -2,6 +2,16 @@
 ARG BASE_IMAGE=ubuntu:22.04
 
 FROM $BASE_IMAGE
+
+# image.version is set during image build by automation
+LABEL org.opencontainers.image.authors="metal3-dev@googlegroups.com"
+LABEL org.opencontainers.image.description="Metal3 Keepalived container image"
+LABEL org.opencontainers.image.documentation="https://github.com/metal3-io/utility-images"
+LABEL org.opencontainers.image.licenses="Apache License 2.0"
+LABEL org.opencontainers.image.title="Metal3 Keepalived"
+LABEL org.opencontainers.image.url="https://github.com/metal3-io/utility-images"
+LABEL org.opencontainers.image.vendor="Metal3-io"
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -y update && \


### PR DESCRIPTION
Add org.opencontainers labels to all three Dockerfiles in the repo. image.version will be set by build automation.