### PR TITLE
🐛 Fix starting keepalived as a non-root user

### DIFF
--- a/keepalived/configure-nonroot.sh
+++ b/keepalived/configure-nonroot.sh
@@ -7,6 +7,8 @@ NONROOT_USER="nonroot"
 NONROOT_GROUP="nonroot"
 NONROOT_UID=65532
 NONROOT_GID=65532
+CUSTOM_CONF_DIR=/conf
+CUSTOM_DATA_DIR=/data
 
 # run as non-root, allow editing the keepalived.conf during startup
 groupadd -g "${NONROOT_GID}" "${NONROOT_GROUP}"
@@ -16,5 +18,8 @@ mkdir -p /run/keepalived
 chown -R root:"${NONROOT_GROUP}" /etc/keepalived /run/keepalived
 chmod 2775 /etc/keepalived /run/keepalived
 chmod 664 /etc/keepalived/keepalived.conf
+
+mkdir -p "${CUSTOM_CONF_DIR}" "${CUSTOM_DATA_DIR}"
+chown "${NONROOT_USER}:${NONROOT_GROUP}" "${CUSTOM_CONF_DIR}" "${CUSTOM_DATA_DIR}"
 
 setcap "cap_net_raw,cap_net_broadcast,cap_net_admin=+eip" /usr/sbin/keepalived


### PR DESCRIPTION
The /conf and /data directories must be initialized during the container
build, otherwise the start-up script won't be able to write to them.
