### PR TITLE
:bug: Align efi output name in ipxe builder

### DIFF
--- a/ipxe-builder/buildipxe.sh
+++ b/ipxe-builder/buildipxe.sh
@@ -90,11 +90,11 @@ sed -i 's/^\/\/#define[ \t]CONSOLE_SERIAL/#define\tCONSOLE_SERIAL/g' \
     "config/console.h"
 
 # shellcheck disable=SC2086
-/usr/bin/make "bin/undionly.kpxe" "bin-${ARCH}-efi/snponly.efi" ${IPXE_BUILD_OPTIONS}
+/usr/bin/make "bin/undionly.kpxe" "bin-${ARCH}-efi/snponly-${ARCH}.efi" ${IPXE_BUILD_OPTIONS}
 
 mkdir -p "${IPXE_CUSTOM_FIRMWARE_DIR}"
 # These files will be copied by the rundnsmasq script to the shared volume.
 cp "/tmp/ipxe-source/src/bin/undionly.kpxe" \
-   "/tmp/ipxe-source/src/bin-${ARCH}-efi/snponly.efi" \
+   "/tmp/ipxe-source/src/bin-${ARCH}-efi/snponly-${ARCH}.efi" \
    "${IPXE_CUSTOM_FIRMWARE_DIR}"
 


### PR DESCRIPTION
This commit:

- Makes the buildipxe script generate architecture specific name for the efi build output. This is required by ironic-image v35.0 and above.
