### PR TITLE
✨ Migrate iPXE building as a new ipxe-binaries image

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -94,3 +94,20 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  build_ipxe-binaries:
+    name: build ipxe-binaries image
+    if: github.repository == 'metal3-io/utility-images'
+    permissions:
+      contents: read
+      id-token: write
+    uses: metal3-io/project-infra/.github/workflows/container-image-build.yml@main # zizmor: ignore[unpinned-uses]
+    with:
+      image-name: 'ipxe-binaries'
+      pushImage: true
+      dockerfile-directory: ipxe-binaries
+      generate-sbom: true
+      sign-image: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/ipxe-binaries-build-pr.yml
+++ b/.github/workflows/ipxe-binaries-build-pr.yml
@@ -1,0 +1,50 @@
+name: Build Ironic Base on PRs
+
+on:
+  pull_request:
+    types: [ opened, edited, reopened, synchronize, ready_for_review ]
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm'}}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        centos_version:
+        - stream9
+        - stream10
+        platform:
+        - linux/amd64
+        - linux/arm64
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+    - name: Set base image
+      id: base-image
+      run: |
+        if [[ "${{ matrix.centos_version }}" == "stream9" ]]; then
+          echo "base_image=quay.io/centos/centos:stream9-minimal" >> "${GITHUB_OUTPUT}"
+        elif [[ "${{ matrix.centos_version }}" == "stream10" ]]; then
+          echo "base_image=quay.io/centos/centos:stream10-minimal" >> "${GITHUB_OUTPUT}"
+        fi
+    - name: Build Docker image
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+      with:
+        context: ipxe-binaries
+        file: ./ipxe-binaries/Dockerfile
+        push: false
+        tags: ipxe-binaries:${{ matrix.centos_version }}
+        platforms: ${{ matrix.platform }}
+        build-args: |
+          BASE_IMAGE=${{ steps.base-image.outputs.base_image }}
+        cache-from: type=gha,scope=${{ matrix.centos_version }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.centos_version }}

--- a/ipxe-binaries/Dockerfile
+++ b/ipxe-binaries/Dockerfile
@@ -15,4 +15,14 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked prepare-ipxe.sh
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked build-ipxe.sh
 
 FROM scratch
+
+# image.version is set during image build by automation
+LABEL org.opencontainers.image.authors="metal3-dev@googlegroups.com"
+LABEL org.opencontainers.image.description="Metal3 iPXE binaries"
+LABEL org.opencontainers.image.documentation="https://github.com/metal3-io/utility-images"
+LABEL org.opencontainers.image.licenses="Apache License 2.0"
+LABEL org.opencontainers.image.title="Metal3 iPXE binaries"
+LABEL org.opencontainers.image.url="https://github.com/metal3-io/utility-images"
+LABEL org.opencontainers.image.vendor="Metal3-io"
+
 COPY --from=ipxe-builder /tmp/ipxe/out/ /ipxe/

--- a/ipxe-binaries/Dockerfile
+++ b/ipxe-binaries/Dockerfile
@@ -1,0 +1,18 @@
+ARG BASE_IMAGE=quay.io/centos/centos:stream9-minimal
+FROM $BASE_IMAGE AS ipxe-builder
+
+## Build iPXE w/ IPv6 Support
+## Note: we are pinning to a specific commit for reproducible builds.
+## Updated as needed.
+ARG IPXE_COMMIT_HASH=d0ea2b1bb8f78b219f74424d435b92ff8aa0ea8d
+ARG TARGETARCH
+
+WORKDIR /tmp
+
+COPY prepare-ipxe.sh build-ipxe.sh /bin/
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked prepare-ipxe.sh
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked build-ipxe.sh
+
+FROM scratch
+COPY --from=ipxe-builder /tmp/ipxe/out/ /ipxe/

--- a/ipxe-binaries/build-ipxe.sh
+++ b/ipxe-binaries/build-ipxe.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/bash
+
+set -euxo pipefail
+
+git clone https://github.com/ipxe/ipxe.git
+cd ipxe
+mkdir out
+git reset --hard "$IPXE_COMMIT_HASH"
+cd src
+
+# Build iPXE binaries based on architecture
+if [[ "$TARGETARCH" == "amd64" ]]; then
+    NO_WERROR=1 make bin/undionly.kpxe bin-x86_64-efi/snponly.efi
+    NO_WERROR=1 make CROSS=aarch64-linux-gnu- bin-arm64-efi/snponly.efi
+elif [[ "$TARGETARCH" == "arm64" ]]; then
+    NO_WERROR=1 make bin-arm64-efi/snponly.efi
+    NO_WERROR=1 make CROSS=x86_64-linux-gnu- bin/undionly.kpxe bin-x86_64-efi/snponly.efi
+else
+    echo "ERROR: Unsupported build architecture: $TARGETARCH"
+    exit 1
+fi
+
+cp bin/undionly.kpxe ../out/
+cp bin-x86_64-efi/snponly.efi ../out/snponly-x86_64.efi
+cp bin-arm64-efi/snponly.efi ../out/snponly-arm64.efi

--- a/ipxe-binaries/build-ipxe.sh
+++ b/ipxe-binaries/build-ipxe.sh
@@ -5,18 +5,18 @@ set -euxo pipefail
 git clone https://github.com/ipxe/ipxe.git
 cd ipxe
 mkdir out
-git reset --hard "$IPXE_COMMIT_HASH"
+git reset --hard "${IPXE_COMMIT_HASH}"
 cd src
 
 # Build iPXE binaries based on architecture
-if [[ "$TARGETARCH" == "amd64" ]]; then
+if [[ "${TARGETARCH}" == "amd64" ]]; then
     NO_WERROR=1 make bin/undionly.kpxe bin-x86_64-efi/snponly.efi
     NO_WERROR=1 make CROSS=aarch64-linux-gnu- bin-arm64-efi/snponly.efi
-elif [[ "$TARGETARCH" == "arm64" ]]; then
+elif [[ "${TARGETARCH}" == "arm64" ]]; then
     NO_WERROR=1 make bin-arm64-efi/snponly.efi
     NO_WERROR=1 make CROSS=x86_64-linux-gnu- bin/undionly.kpxe bin-x86_64-efi/snponly.efi
 else
-    echo "ERROR: Unsupported build architecture: $TARGETARCH"
+    echo "ERROR: Unsupported build architecture: ${TARGETARCH}"
     exit 1
 fi
 

--- a/ipxe-binaries/prepare-ipxe.sh
+++ b/ipxe-binaries/prepare-ipxe.sh
@@ -14,15 +14,15 @@ dnf config-manager --set-disabled epel && \
 dnf install -y git-core make perl xz-devel
 
 # Install appropriate gcc binaries based on build architecture
-if [[ "$TARGETARCH" == "amd64" ]]; then
+if [[ "${TARGETARCH}" == "amd64" ]]; then
     # On x86_64, we need native gcc for x86 builds and cross-compiler for arm64
     dnf install -y gcc && \
     dnf install --enablerepo=epel -y gcc-aarch64-linux-gnu gcc-c++-aarch64-linux-gnu
-elif [[ "$TARGETARCH" == "arm64" ]]; then
+elif [[ "${TARGETARCH}" == "arm64" ]]; then
     # On arm64, we need native gcc for arm64 builds and cross-compiler for x86_64
     dnf install -y gcc && \
     dnf install --enablerepo=epel -y gcc-x86_64-linux-gnu gcc-c++-x86_64-linux-gnu
 else
-    echo "ERROR: Unsupported build architecture: $TARGETARCH"
+    echo "ERROR: Unsupported build architecture: ${TARGETARCH}"
     exit 1
 fi

--- a/ipxe-binaries/prepare-ipxe.sh
+++ b/ipxe-binaries/prepare-ipxe.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+
+set -euxo pipefail
+
+# The minimal base image only has microdnf, install dnf first
+# dnf-plugins-core provides config-manager
+microdnf install -y dnf dnf-plugins-core
+
+echo "install_weak_deps=False" >> /etc/dnf/dnf.conf && \
+echo "tsflags=nodocs" >> /etc/dnf/dnf.conf && \
+echo "keepcache=1" >> /etc/dnf/dnf.conf && \
+dnf install -y epel-release && \
+dnf config-manager --set-disabled epel && \
+dnf install -y git-core make perl xz-devel
+
+# Install appropriate gcc binaries based on build architecture
+if [[ "$TARGETARCH" == "amd64" ]]; then
+    # On x86_64, we need native gcc for x86 builds and cross-compiler for arm64
+    dnf install -y gcc && \
+    dnf install --enablerepo=epel -y gcc-aarch64-linux-gnu gcc-c++-aarch64-linux-gnu
+elif [[ "$TARGETARCH" == "arm64" ]]; then
+    # On arm64, we need native gcc for arm64 builds and cross-compiler for x86_64
+    dnf install -y gcc && \
+    dnf install --enablerepo=epel -y gcc-x86_64-linux-gnu gcc-c++-x86_64-linux-gnu
+else
+    echo "ERROR: Unsupported build architecture: $TARGETARCH"
+    exit 1
+fi


### PR DESCRIPTION
Building iPXE from source takes a significant proportion of the time it
takes to build ironic-image, although the iPXE hash only changes
occasionally. By moving the build into a new base image, we're going
to remove many minutes of build time from ironic-image.

See-also: https://github.com/metal3-io/ironic-image/issues/1006
Signed-off-by: Dmitry Tantsur <dtantsur@protonmail.com>
