### PR TITLE
:sparkles: Enable multi-arch build for ipxe-binaries image

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -105,6 +105,8 @@ jobs:
       image-name: 'ipxe-binaries'
       pushImage: true
       dockerfile-directory: ipxe-binaries
+      multiPlatform: true
+      platform: "linux/amd64,linux/arm64"
       generate-sbom: true
       sign-image: true
     secrets:


### PR DESCRIPTION
The ipxe-binaries image was published as amd64-only, causing platform mismatch warnings in downstream arm64 builds (e.g. ironic-image). Enable multiPlatform with linux/amd64 and linux/arm64 so the published manifest covers both architectures.

Fixes: https://github.com/metal3-io/ironic-image/issues/1027