### PR TITLE
🌱 Bump checkout actions to v7

### DIFF
--- a/.github/workflows/cloud-init-tool-build-pr.yml
+++ b/.github/workflows/cloud-init-tool-build-pr.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Set up Docker Buildx

--- a/.github/workflows/copilot-review-prow-plugin-build-pr.yml
+++ b/.github/workflows/copilot-review-prow-plugin-build-pr.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Set up Docker Buildx

--- a/.github/workflows/fake-ipa-build-pr.yml
+++ b/.github/workflows/fake-ipa-build-pr.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Set up Docker Buildx

--- a/.github/workflows/ipxe-binaries-build-pr.yml
+++ b/.github/workflows/ipxe-binaries-build-pr.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Set up Docker Buildx

--- a/.github/workflows/ipxe-builder-build-pr.yml
+++ b/.github/workflows/ipxe-builder-build-pr.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Set up Docker Buildx

--- a/.github/workflows/keepalived-build-pr.yml
+++ b/.github/workflows/keepalived-build-pr.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Set up Docker Buildx

--- a/.github/workflows/validate-security-insights.yml
+++ b/.github/workflows/validate-security-insights.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     # Upload SARIF to Security tab on push to main


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump checkout action to v7.
Major version bumps has to be done manually since dependabot is configured to ignore them.

<!-- Which issue(s) this PR fixes. Optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged. -->

Fixes #

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
