### PR TITLE
:sparkles: Add configurable VRID and VRRP authentication to keepalived image

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ hold the keepalived and vrrp pid files
 - `KEEPALIVED_VIRTUAL_IPS` - Space-separated list of virtual IPs with their
   interfaces. Each entry has format: `ip,interface[,prefix]`. When set, this
   takes precedence over `PROVISIONING_IP` and `PROVISIONING_INTERFACE`.
+- `KEEPALIVED_VRID` - VRRP virtual router ID, an integer in the range 1..255
+  (default `1`)
+- `KEEPALIVED_AUTH_PASS` - VRRP simple authentication password, given inline
+- `KEEPALIVED_AUTH_PASS_FILE` - path to a file holding the VRRP authentication
+  password, typically a mounted Secret. Mutually exclusive with
+  `KEEPALIVED_AUTH_PASS`
+
+`KEEPALIVED_VRID` and the authentication password must match on all peers of
+the same VRRP group. See [keepalived/README.md](keepalived/README.md) for the
+full description of these options.
 
 ### Configuration Modes
 

--- a/keepalived/README.md
+++ b/keepalived/README.md
@@ -1,0 +1,111 @@
+# Metal3 Keepalived
+
+Keepalived container used in Ironic deployments. Keepalived provides a fixed
+IP address for Ironic in such a manner that even after pivoting operations the
+IP of Ironic stays persistent.
+
+See the [Keepalived documentation](https://www.keepalived.org/manpage.html)
+for the meaning of the underlying directives.
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CUSTOM_CONF_DIR` | `/conf` | A subdirectory named `keepalived` is created under this path, the config file is copied there and the variable substitution happens in that copy |
+| `CUSTOM_DATA_DIR` | `/data` | A subdirectory named `keepalived` is created here to hold the keepalived and vrrp pid files |
+| `PROVISIONING_IP` | - | The fixed IP provided by keepalived (legacy mode, see below) |
+| `PROVISIONING_INTERFACE` | - | The name of the interface that will be used to "host" the fixed IP (legacy mode, see below) |
+| `KEEPALIVED_VIRTUAL_IPS` | - | Space-separated list of virtual IPs with their interfaces, each entry has the format `ip,interface[,prefix]`. When set, it takes precedence over `PROVISIONING_IP` and `PROVISIONING_INTERFACE` |
+| `KEEPALIVED_VRID` | `1` | VRRP virtual router ID, an integer in the range 1..255 |
+| `KEEPALIVED_AUTH_PASS` | - | VRRP simple authentication password, given inline. When unset and `KEEPALIVED_AUTH_PASS_FILE` is also unset, no `authentication` block is generated |
+| `KEEPALIVED_AUTH_PASS_FILE` | - | Path to a file holding the VRRP authentication password, typically a mounted Secret. Mutually exclusive with `KEEPALIVED_AUTH_PASS` |
+
+## Configuration modes
+
+**Legacy mode** (single IP): Use `PROVISIONING_IP` and `PROVISIONING_INTERFACE`
+for simple single-IP deployments. The script automatically detects IPv4 vs IPv6
+and applies the correct prefix (`/32` for IPv4, `/128` for IPv6).
+
+```bash
+PROVISIONING_IP=192.168.0.100
+PROVISIONING_INTERFACE=eth0
+```
+
+**Multi-IP mode**: Use `KEEPALIVED_VIRTUAL_IPS` for multiple IPs, different
+interfaces, or mixed IPv4/IPv6 deployments. Format is space-separated entries
+where each entry is `ip,interface[,prefix]`.
+
+```bash
+# Two IPs on different interfaces
+KEEPALIVED_VIRTUAL_IPS="192.168.0.100,eth0 192.168.1.50,eth1"
+
+# IPv6 with link-local address
+KEEPALIVED_VIRTUAL_IPS="fe80::1,eth0,64 fd00::100,eth0,128"
+
+# Mixed IPv4 and IPv6
+KEEPALIVED_VIRTUAL_IPS="192.168.0.100,eth0 fd00::100,eth0"
+```
+
+## Virtual router ID
+
+`KEEPALIVED_VRID` sets the `virtual_router_id` of the VRRP instance and
+defaults to `1`. It must be identical on every peer that takes part in the same
+VRRP group, and it must be unique among the VRRP groups that share a broadcast
+domain, otherwise unrelated instances will fight over the same virtual IP.
+
+```bash
+KEEPALIVED_VRID=51
+```
+
+## VRRP authentication
+
+Setting a password enables VRRP simple authentication, which adds the
+following block to the generated configuration:
+
+```text
+authentication {
+    auth_type PASS
+    auth_pass <password>
+}
+```
+
+The recommended way to pass the password is `KEEPALIVED_AUTH_PASS_FILE`
+pointing at a mounted Secret, so that the plaintext never appears in the pod
+spec:
+
+```bash
+KEEPALIVED_AUTH_PASS_FILE=/etc/keepalived-auth/password
+```
+
+The password may also be given inline for local testing:
+
+```bash
+KEEPALIVED_AUTH_PASS=m3talpwd
+```
+
+Setting both variables at once is an error and the container exits.
+
+The password must not contain whitespace, double quotes, backslashes, `~` or
+non-printable characters. Leading and trailing whitespace is trimmed from the
+file form, so a trailing newline in a Secret is harmless.
+
+VRRP truncates `auth_pass` to 8 bytes, so only the first 8 characters take
+part in the comparison between peers. A longer password is accepted but logs a
+warning.
+
+The password never appears in the container logs. It is only written to the
+generated `keepalived.conf` inside the container.
+
+## Matching the settings across peers
+
+`KEEPALIVED_VRID` and the authentication password must match on all peers of
+the same VRRP group. When they do not match, the peers cannot recognise each
+other's advertisements, every node promotes itself to MASTER, and the virtual
+IP ends up assigned on more than one host at the same time (split brain /
+duplicate VIP).
+
+## Notes
+
+If run with a container that has a read-only root file-system, then
+`CUSTOM_CONF_DIR`, `CUSTOM_DATA_DIR` and `/var/log` paths have to be mounted
+from an external volume.

--- a/keepalived/manage-keepalived.sh
+++ b/keepalived/manage-keepalived.sh
@@ -64,8 +64,74 @@ else
     assignedIP=$(format_ip_with_prefix "${PROVISIONING_IP}")
 fi
 
+vrid="${KEEPALIVED_VRID:-1}"
+if [[ ! "${vrid}" =~ ^[0-9]+$ ]] || (( 10#${vrid} < 1 || 10#${vrid} > 255 )); then
+    echo "ERROR: KEEPALIVED_VRID must be an integer in the range 1..255," \
+         "got '${vrid}'" >&2
+    exit 1
+fi
+
+# Tracing is disabled from here on so that the password never reaches the
+# `set -x` output. VRRP truncates auth_pass to 8 bytes, only those are compared.
+set +x
+auth_pass=""
+if [[ -n "${KEEPALIVED_AUTH_PASS:-}" && -n "${KEEPALIVED_AUTH_PASS_FILE:-}" ]]; then
+    echo "ERROR: KEEPALIVED_AUTH_PASS and KEEPALIVED_AUTH_PASS_FILE are" \
+         "mutually exclusive, set only one of them" >&2
+    exit 1
+elif [[ -n "${KEEPALIVED_AUTH_PASS:-}" ]]; then
+    auth_pass="${KEEPALIVED_AUTH_PASS}"
+elif [[ -n "${KEEPALIVED_AUTH_PASS_FILE:-}" ]]; then
+    if [[ ! -r "${KEEPALIVED_AUTH_PASS_FILE}" ]]; then
+        echo "ERROR: KEEPALIVED_AUTH_PASS_FILE" \
+             "'${KEEPALIVED_AUTH_PASS_FILE}' does not exist or is not" \
+             "readable" >&2
+        exit 1
+    fi
+    auth_pass="$(cat -- "${KEEPALIVED_AUTH_PASS_FILE}")"
+    auth_pass="${auth_pass#"${auth_pass%%[![:space:]]*}"}"
+    auth_pass="${auth_pass%"${auth_pass##*[![:space:]]}"}"
+    if [[ -z "${auth_pass}" ]]; then
+        echo "ERROR: KEEPALIVED_AUTH_PASS_FILE" \
+             "'${KEEPALIVED_AUTH_PASS_FILE}' is empty" >&2
+        exit 1
+    fi
+fi
+
+if [[ -n "${auth_pass}" ]]; then
+    if [[ "${auth_pass}" == *[[:space:]]* ]] \
+        || [[ "${auth_pass}" == *['"\~']* ]] \
+        || [[ "${auth_pass}" =~ [^[:print:]] ]]; then
+        echo "ERROR: the VRRP authentication password must not contain" \
+             "whitespace, double quotes, backslashes, '~' or non-printable" \
+             "characters" >&2
+        exit 1
+    fi
+    if (( ${#auth_pass} > 8 )); then
+        echo "WARNING: the VRRP authentication password is" \
+             "${#auth_pass} characters long; VRRP truncates it to 8 bytes," \
+             "only the first 8 are significant" >&2
+    fi
+    authentication="authentication {
+        auth_type PASS
+        auth_pass ${auth_pass//&/\\&}
+    }"
+    # Escape newlines for sed replacement: replace newline with backslash-newline
+    auth_expr="s~AUTHENTICATION~${authentication//$'\n'/\\
+}~"
+else
+    auth_expr='/AUTHENTICATION/d'
+fi
+unset auth_pass authentication KEEPALIVED_AUTH_PASS
+set -x
+
 sed -i "s~INTERFACE~${interface}~g" "${KEEPALIVED_CONF}"
 sed -i "s~CHANGEIP~${assignedIP}~g" "${KEEPALIVED_CONF}"
+sed -i "s~VRID~${vrid}~g" "${KEEPALIVED_CONF}"
+set +x
+sed -i "${auth_expr}" "${KEEPALIVED_CONF}"
+unset auth_expr
+set -x
 
 exec /usr/sbin/keepalived --dont-fork --log-console \
     --pid="${KEEPALIVED_DATA_DIR}/keepalived.pid" \

--- a/keepalived/sample.keepalived.conf
+++ b/keepalived/sample.keepalived.conf
@@ -11,9 +11,10 @@ global_defs {
 vrrp_instance VI_1 {
     state MASTER
     interface INTERFACE
-    virtual_router_id 1
+    virtual_router_id VRID
     priority 101
     advert_int 1
+    AUTHENTICATION
     virtual_ipaddress {
         CHANGEIP
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Two VRRP settings are currently impossible to configure without patching the
generated config file from outside the container:

1. the virtual router ID, hardcoded as `virtual_router_id 1`
2. VRRP simple authentication, which the template does not contain at all

This adds two template placeholders, `VRID` and `AUTHENTICATION`, substituted in
`manage-keepalived.sh` the same way `INTERFACE` and `CHANGEIP` already are.

This is the upstream half of metal3-io/ironic-standalone-operator#686. That PR
originally patched the config with `sed` from the operator side; reviewers
(@Rozzii, @lentzi90, @dtantsur) asked for the support to live in the image
instead, driven by placeholders. IrSO will consume these environment variables
once this is merged.

**New environment variables**

| Variable | Default | Description |
|----------|---------|-------------|
| `KEEPALIVED_VRID` | `1` | `virtual_router_id`, validated to be an integer in 1..255 |
| `KEEPALIVED_AUTH_PASS` | - | `auth_pass` value, given inline |
| `KEEPALIVED_AUTH_PASS_FILE` | - | Same password read from a file, for a mounted Secret. Mutually exclusive with `KEEPALIVED_AUTH_PASS` |

`auth_type` is hardcoded to `PASS`. keepalived also supports `AH`, but it is
deprecated and effectively unused, so it did not seem worth a knob. Happy to
add one if you disagree.

On naming: everything the image owns is already prefixed with `KEEPALIVED_`
(`KEEPALIVED_VIRTUAL_IPS`), the only unprefixed variables being the legacy
`PROVISIONING_IP` / `PROVISIONING_INTERFACE` pair. `KEEPALIVED_AUTH_PASS`
mirrors the `auth_pass` directive and `KEEPALIVED_VRID` matches the `vrid`
field name on the IrSO side, so the two repos line up.

**Backward compatibility**

When neither password variable is set, the `AUTHENTICATION` placeholder line is
deleted, so the generated `keepalived.conf` is byte identical to the one
produced before this change. Verified by diffing the output of the pre-change
image against the new one — same md5. Both the legacy `PROVISIONING_IP` /
`PROVISIONING_INTERFACE` and the `KEEPALIVED_VIRTUAL_IPS` code paths are
untouched and keep working.

**Password handling**

The script runs under `set -eux`, so the password resolution and the `sed`
command carrying the plaintext run with tracing disabled — otherwise the
password would be printed to the container logs. See the open question below.

The value is validated before use: empty, whitespace, `"`, `\`, `~` and
non-printable characters are rejected with a clear error. `~` is the sed
delimiter used here and the others would either break the substitution or
produce a config keepalived refuses to parse. A password longer than 8 bytes is
accepted but logs a warning, since VRRP silently truncates `auth_pass` to 8
bytes and only those take part in the comparison between peers.

**Testing**

Built the image locally and inspected the generated
`/conf/keepalived/keepalived.conf` in each case:

| Case | Result |
|------|--------|
| Neither variable set (legacy `PROVISIONING_*`) | Config byte identical to pre-change image |
| `KEEPALIVED_VRID` only | `virtual_router_id 51` |
| Password only | `authentication` block added before `virtual_ipaddress` |
| VRID + password + `KEEPALIVED_VIRTUAL_IPS` | Both applied, multi-IP block intact |
| `KEEPALIVED_AUTH_PASS_FILE` | Password read, trailing newline trimmed |
| Password longer than 8 bytes | Warning logged, config still generated |
| Invalid VRID (`0`, `256`, `abc`) | Exit 1 with a clear message |
| Invalid password (`~`, space, `"`, `\`) | Exit 1 with a clear message |
| Missing password file | Exit 1 with a clear message |
| Both password variables set | Exit 1 with a clear message |

All failure cases exit non-zero before keepalived starts, and the password does
not appear in stdout or stderr in any case. `keepalived --config-test` accepts
the generated config with VRID and authentication set.

`./hack/shellcheck.sh` and `./hack/markdownlint.sh` both pass.

**Open questions for reviewers**

I would like a second opinion on two choices before this merges. Both are easy
to change, so please just say which way you prefer.

1. **`keepalived/README.md` as a separate file.** All keepalived environment
   variables, including the pre-existing ones, are documented in a new
   `keepalived/README.md`, and the main `README.md` keeps a short list of the
   variables plus a link to it. `fake-ipa`, `cloud-init-tool` and
   `copilot-review-prow-plugin` already have per-directory READMEs, so this
   seemed consistent, but `fake-ipa`'s content is also duplicated verbatim into
   the main `README.md`, and that duplication is exactly what tends to drift.
   Alternatives: document everything in the main `README.md` only and drop
   `keepalived/README.md`, or move the whole keepalived section out of the main
   `README.md` and leave only a link. I am fine with any of the three.

2. **`set +x` around the password handling.** With `set -eux` in force, both
   `auth_pass="${KEEPALIVED_AUTH_PASS}"` and the `sed` command that embeds the
   password are echoed to stderr, so the plaintext lands in the container logs
   and in whatever aggregator collects them. To avoid that, the password
   resolution and that one `sed` run between `set +x` and `set -x`. The cost is
   that the script no longer traces uniformly and two lines of the substitution
   block are invisible when debugging. Alternatives: drop the `set +x` and
   accept the password in the logs, or drop `u`/`x` from `set -eux` for the
   whole script. I lean towards keeping it as is, but this repo's convention is
   `set -eux` everywhere, so I would rather have this confirmed than assume.

   Worth noting either way: `set +x` only keeps the password out of the logs.
   With `KEEPALIVED_AUTH_PASS` the value is still in the container environment
   and readable via the pod spec, which is why `KEEPALIVED_AUTH_PASS_FILE` is
   the recommended form and the one IrSO will use.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] E2E tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.

The repository has no test harness for the shell entrypoints, so the cases
above were verified manually against a locally built image. 